### PR TITLE
Df/fix #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage
 build
 .DS_Store
 .rdb
+/.idea
+/dump.rdb

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build/doc"
   ],
   "scripts": {
-    "start": "npm run build && node ./build/src/run.js",
+    "start": "npm run build && node ./build/run.js",
     "clean": "rm -Rf .nyc_output && rm -Rf coverage && rm -Rf build ",
     "build": "tsc",
     "lint": "tslint --project .",

--- a/run-alice.sh
+++ b/run-alice.sh
@@ -1,0 +1,5 @@
+LEDGER_ADDRESS=rPtZP6jEcAMo2v1aVAJqoqqoZThRTx2voE \
+LEDGER_SECRET=snH5tCJWYszQWRTBe61ssV617pzn6 \
+ENGINE_PORT=9000 \
+CONNECTOR_URL=http://localhost:8080 \
+npm run-script start

--- a/run-bob.sh
+++ b/run-bob.sh
@@ -1,0 +1,5 @@
+LEDGER_ADDRESS=rdVEU3RfkW4q9Fg3BTBhaNJr8gy9pZRrw \
+LEDGER_SECRET=shcuUXdrZKUvZXSvq3zuPxXRB5Hbs \
+ENGINE_PORT=9001 \
+CONNECTOR_URL=http://localhost:8081 \
+npm run-script start

--- a/src/controllers/accountsController.ts
+++ b/src/controllers/accountsController.ts
@@ -1,17 +1,24 @@
 import { Context } from 'koa'
-import { Redis } from 'ioredis'
 import { Account } from '../models/account'
+import { v4 as uuidv4 } from 'uuid'
 
 export async function create (ctx: Context) {
   let body = ctx.request.body
+
+  // If no accountId is specified, create a type4 UUID for the request.
+  let accountId = body.id ? body.id : uuidv4()
+
   let account: Account = {
-    id: body.id
+    id: accountId
   }
 
-    // Check if account exists first
+  // Check if account exists first
   const existingAccount = await ctx.redis.get(`${ctx.settlement_prefix}:accounts:${account.id}`)
-  if (!existingAccount) {
+  if (existingAccount) {
+    ctx.body = JSON.parse(existingAccount)
+  } else {
     await ctx.redis.set(`${ctx.settlement_prefix}:accounts:${account.id}`, JSON.stringify(account))
+    ctx.body = account
   }
 
   ctx.status = 200
@@ -33,5 +40,5 @@ export async function destroy (ctx: Context) {
   await ctx.redis.del(`${ctx.settlement_prefix}:accounts:${ctx.params.id}`)
     // TODO Delete key from redis for ledger address
 
-  ctx.status = 200
+  ctx.status = 204
 }

--- a/src/controllers/accountsController.ts
+++ b/src/controllers/accountsController.ts
@@ -21,7 +21,7 @@ export async function create (ctx: Context) {
     ctx.body = account
   }
 
-  ctx.status = 200
+  ctx.status = 201
 }
 
 /** Get account by Id */

--- a/src/controllers/accountsSettlementController.ts
+++ b/src/controllers/accountsSettlementController.ts
@@ -1,5 +1,4 @@
 import { Context } from 'koa'
-import { Redis } from 'ioredis'
 import { normalizeAsset } from '../utils/normalizeAsset'
 
 export async function create (ctx: Context) {
@@ -7,8 +6,16 @@ export async function create (ctx: Context) {
   const account = JSON.parse(accountJson)
 
   const body = ctx.request.body
-  const amount = normalizeAsset(body.scale, 6, BigInt(body.amount))
+  const clearingScale = body.scale
+  const amount = normalizeAsset(clearingScale, 6, BigInt(body.amount))
+
   await ctx.settleAccount(account, amount.toString())
 
-  ctx.status = 200
+  let settlementComittment = {
+    scale: 6,
+    amount: amount.toString()
+  }
+
+  ctx.body = settlementComittment
+  ctx.status = 201
 }

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -43,7 +43,7 @@ describe('Accounts', function () {
   it('can add an account', async () => {
     const response = await axios.post('http://localhost:3000/accounts', dummyAccount).catch(error => {throw new Error(error.message)})
 
-    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.status, 201)
     const account = await redis.get('xrp:accounts:testId')
     if(account) {
       assert.deepEqual(JSON.parse(account), dummyAccount)
@@ -60,7 +60,7 @@ describe('Accounts', function () {
 
     const response = await axios.post('http://localhost:3000/accounts', dummyAccount).catch(error => {throw new Error(error.message)})
 
-    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.status, 201)
     const account = await redis.get('xrp:accounts:testId')
     if(account) {
       assert.deepEqual(JSON.parse(account), existingAccount)
@@ -73,7 +73,7 @@ describe('Accounts', function () {
     await redis.set(`xrp:accounts:${dummyAccount.id}`, JSON.stringify(dummyAccount))
 
     const response = await axios.get(`http://localhost:3000/accounts/${dummyAccount.id}`).catch(error => {throw new Error(error.message)})
-    
+
     assert.strictEqual(response.status, 200)
     assert.deepEqual(response.data, dummyAccount)
   })
@@ -83,7 +83,7 @@ describe('Accounts', function () {
 
     const response = await axios.delete(`http://localhost:3000/accounts/${dummyAccount.id}`).catch(error => {throw new Error(error.message)})
 
-    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.status, 204)
     const account = await redis.get('xrp:accounts:testId')
     assert.isNull(account)
   })

--- a/test/settlement.test.ts
+++ b/test/settlement.test.ts
@@ -135,7 +135,7 @@ describe('Accounts Settlement', function () {
       assert.deepEqual(request.body.json, {
         type: 'paymentDetails'
       })
-      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.status, 201)
     })
   })
 })


### PR DESCRIPTION
* Add a JSON response for the settlement message that returns the amount settled.
* Add a JSON response for the create account endpoint.
* Fix HTTP status code to be `204` after a successful HTTP `DELETE` request.
* Add some helper scripts for running two settlement engines.